### PR TITLE
extras/ads1x1x.py: Add support for i2c based ADC chip

### DIFF
--- a/config/printer-picksix-v02.cfg
+++ b/config/printer-picksix-v02.cfg
@@ -1,0 +1,401 @@
+#
+# TMC Debug command:
+#
+# DUMP_TMC STEPPER=stepper_x
+# SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=40
+# TURN_OFF_HEATERS
+# FORCE_MOVE STEPPER=stepper_x DISTANCE=10 VELOCITY=60
+# FORCE_MOVE STEPPER=stepper_y DISTANCE=10 VELOCITY=60
+# QUERY_ENDSTOPS
+#
+# BED_MESH_CALIBRATE PROFILE=default METHOD=automatic
+#
+# GPIO Extender gpio30 - gpio45
+#
+# GPIO29 - IP Used in ADC mode (ADC3) to measure VSYS/3
+# GPIO24 - IP VBUS sense - high if VBUS is present, else low
+# GPIO23 - OP Controls the on-board SMPS Power Save pin
+
+# Mainsail
+[include mainsail.cfg]
+
+[include macros.cfg]
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_rp2040_E660A493174C8E2D-if00
+restart_method: command
+
+
+[virtual_sdcard]
+path: /home/pi/gcode_files
+
+[output_pin pico_led]
+pin: gpio25
+
+##
+# For testing purposes only
+##
+[force_move]
+enable_force_move: True
+#   Set to true to enable FORCE_MOVE and SET_KINEMATIC_POSITION
+#   extended G-Code commands. The default is false.
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 3500
+max_z_velocity: 15
+max_z_accel: 20
+square_corner_velocity: 5
+
+# MT1
+[stepper_x]
+step_pin: gpio10
+dir_pin: gpio11
+endstop_pin: gpio30
+#step_pulse_duration: 0.000000120
+microsteps: 16
+rotation_distance: 31.72
+full_steps_per_rotation: 200
+position_max: 300
+homing_speed: 20
+position_endstop: 0
+homing_retract_dist: 0
+
+[tmc2209 stepper_x]
+uart_pin: gpio13
+tx_pin: gpio12
+uart_address: 0
+interpolate: true
+run_current: 0.8
+driver_SGTHRS: 38
+
+# MT2
+[stepper_y]
+step_pin: gpio14
+dir_pin: !gpio15
+endstop_pin: gpio31
+#step_pulse_duration: 0.000000120
+microsteps: 16
+rotation_distance: 31.72
+full_steps_per_rotation: 200
+position_endstop: 0
+homing_positive_dir: false
+position_max: 300
+homing_speed: 20
+homing_retract_dist: 0
+
+[tmc2209 stepper_y]
+uart_pin: gpio13
+tx_pin: gpio12
+uart_address: 1
+interpolate: true
+run_current: 0.8
+driver_SGTHRS: 38
+
+# MT3
+[stepper_z]
+step_pin: gpio17
+dir_pin: gpio18
+endstop_pin: probe:z_virtual_endstop
+#step_pulse_duration: 0.000000120
+microsteps: 4
+full_steps_per_rotation: 200
+rotation_distance: 4
+position_max: 300
+position_min: -4 # The Z carriage may need to travel below the Z=0
+                 # homing point if the bed has a significant tilt.
+homing_retract_dist: 0
+homing_speed: 15
+
+[tmc2209 stepper_z]
+uart_pin: gpio13
+tx_pin: gpio12
+uart_address: 2
+interpolate: true
+run_current: 0.707
+stealthchop_threshold: 0
+driver_SGTHRS: 55
+
+# MT4
+[stepper_z1]
+#step_pulse_duration: 0.000000120
+step_pin: gpio19
+dir_pin: gpio20
+microsteps: 4
+full_steps_per_rotation: 200
+rotation_distance: 4
+
+[tmc2209 stepper_z1]
+uart_pin: gpio13
+tx_pin: gpio12
+uart_address: 3
+interpolate: true
+run_current: 0.707
+stealthchop_threshold: 0
+driver_SGTHRS: 55
+
+# MT6
+[stepper_z2]
+#step_pulse_duration: 0.000000120
+step_pin: gpio26
+dir_pin: gpio27
+microsteps: 4
+full_steps_per_rotation: 200
+rotation_distance: 4
+
+[tmc2209 stepper_z2]
+uart_pin: gpio9
+tx_pin: gpio8
+uart_address: 1
+interpolate: true
+run_current: 0.707
+stealthchop_threshold: 0
+driver_SGTHRS: 55
+
+# MT5
+[extruder]
+step_pin: gpio21
+dir_pin: !gpio22
+heater_pin: gpio43
+#step_pulse_duration: 0.000000120
+max_extrude_only_velocity: 60
+max_extrude_only_distance: 50
+microsteps: 16
+rotation_distance: 15.543
+full_steps_per_rotation: 400
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+min_extrude_temp: 180
+min_temp: 15
+max_temp: 285
+pressure_advance: 0.068
+# For temp sensor
+sensor_type: ADS1X1X
+probe_type: Generic 3950
+pullup_resistor: 4700
+i2c_mcu: mcu
+i2c_bus: i2c1b
+ads1x1_chip: 5
+ads1x1_mux: 16384 # AIN0
+# Pullup voltage on thermistor
+adc_voltage: 3.265
+# Sensor is reading this amount different from external measuring device
+voltage_offset: -0.295
+
+[tmc2208 extruder]
+uart_pin: gpio9
+tx_pin: gpio8
+uart_address: 0
+run_current: 0.800
+stealthchop_threshold: 0
+
+[verify_heater extruder]
+max_error: 240
+check_gain_time: 40
+
+#[firmware_retraction]
+#retract_speed: 40
+#retract_length: 0.5
+#unretract_extra_length: 0
+#unretract_speed: 40
+
+[probe]
+pin: !gpio32
+x_offset: -29
+y_offset: 22
+speed: 15
+samples: 1
+sample_retract_dist: 2
+lift_speed: 5
+samples_result: median
+samples_tolerance: 0.02
+samples_tolerance_retries: 5
+
+[heater_bed]
+heater_pin: gpio42
+min_temp: 0
+max_temp: 120
+# For temp sensor
+sensor_type: ADS1X1X
+probe_type: Generic 3950
+i2c_mcu: mcu
+i2c_bus: i2c1b
+ads1x1_chip: 5
+ads1x1_mux: 20480 #AIN1
+# Pullup voltage on thermistor
+adc_voltage: 3.265
+# Sensor is reading this amount different from external measuring device
+voltage_offset: -0.295
+
+[verify_heater heater_bed]
+max_error: 240
+check_gain_time: 60
+
+[output_pin ht2]
+pin: gpio44
+#   The pin to configure as an output. This parameter must be
+#   provided.
+#pwm: False
+#   Set if the output pin should be capable of pulse-width-modulation.
+#   If this is true, the value fields should be between 0 and 1; if it
+#   is false the value fields should be either 0 or 1. The default is
+#   False.
+#static_value:
+#   If this is set, then the pin is assigned to this value at startup
+#   and the pin can not be changed during runtime. A static pin uses
+#   slightly less ram in the micro-controller. The default is to use
+#   runtime configuration of pins.
+#value:
+#   The value to initially set the pin to during MCU configuration.
+#   The default is 0 (for low voltage).
+#shutdown_value:
+#   The value to set the pin to on an MCU shutdown event. The default
+#   is 0 (for low voltage).
+#maximum_mcu_duration:
+#   The maximum duration a non-shutdown value may be driven by the MCU
+#   without an acknowledge from the host.
+#   If host can not keep up with an update, the MCU will shutdown
+#   and set all pins to their respective shutdown values.
+#   Default: 0 (disabled)
+#   Usual values are around 5 seconds.
+#cycle_time: 0.100
+#   The amount of time (in seconds) per PWM cycle. It is recommended
+#   this be 10 milliseconds or greater when using software based PWM.
+#   The default is 0.100 seconds for pwm pins.
+#hardware_pwm: False
+#   Enable this to use hardware PWM instead of software PWM. When
+#   using hardware PWM the actual cycle time is constrained by the
+#   implementation and may be significantly different than the
+#   requested cycle_time. The default is False.
+#scale:
+#   This parameter can be used to alter how the 'value' and
+#   'shutdown_value' parameters are interpreted for pwm pins. If
+#   provided, then the 'value' parameter should be between 0.0 and
+#   'scale'. This may be useful when configuring a PWM pin that
+#   controls a stepper voltage reference. The 'scale' can be set to
+#   the equivalent stepper amperage if the PWM were fully enabled, and
+#   then the 'value' parameter can be specified using the desired
+#   amperage for the stepper. The default is to not scale the 'value'
+#   parameter.
+
+[output_pin ht3]
+pin: gpio45
+
+#[filament_motion_sensor filament_motion]
+#detection_length: 7.0
+#   The minimum length of filament pulled through the sensor to trigger
+#   a state change on the switch_pin
+#   Default is 7 mm.
+#extruder: extruder
+#   The name of the extruder section this sensor is associated with.
+#   This parameter must be provided.
+#switch_pin: gpio35
+#pause_on_runout:
+#runout_gcode:
+#insert_gcode:
+#event_delay:
+#pause_delay:
+#   See the "filament_switch_sensor" section for a description of the
+#   above parameters.
+
+[bed_mesh]
+horizontal_move_z: 5
+mesh_min: 20,30
+mesh_max: 240,260
+probe_count: 7,7
+fade_start: 1.0
+fade_end: 10.0
+mesh_pps: 2,2
+algorithm: bicubic
+bicubic_tension: .2
+speed: 100
+
+[z_tilt]
+z_positions:
+    150,0
+    300,300
+    0,300
+
+points:
+    155,60
+    240,270
+    60,270
+
+horizontal_move_z: 12
+retries: 10
+retry_tolerance: 0.02
+speed: 200
+
+[safe_z_home]
+home_xy_position: 143, 128
+speed: 50
+z_hop: 5
+z_hop_speed: 15
+
+######################################################################
+# AZSMZ 12864 LCD (uc1701)
+######################################################################
+
+[display]
+lcd_type: uc1701
+encoder_pins: ^gpio37, ^gpio39
+encoder_steps_per_detent: 2
+click_pin: ^!gpio38
+cs_pin: gpio16
+a0_pin: gpio40
+contrast: 60
+spi_bus: spi0e
+spi_speed: 26000000
+
+[output_pin beeper]
+pin: gpio36
+
+#[sdcard]
+#spi_bus: spi0
+#cs_pin: gpio1
+#card_detect: gpio41
+
+# Some PWM device -- this pin is hardware configured for 3.3/5/24V switched output
+# selectable by a jumper.
+#[fan]
+#pin: gpio28
+
+#*# <---------------------- SAVE_CONFIG ---------------------->
+#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
+#*#
+#*# [bed_mesh default]
+#*# version = 1
+#*# points =
+#*#     0.100000, 0.070000, 0.055000, 0.040000, 0.030000, 0.000000, 0.020000
+#*#     0.105000, 0.065000, 0.050000, 0.040000, 0.040000, 0.020000, 0.035000
+#*#     0.140000, 0.095000, 0.065000, 0.055000, 0.050000, 0.040000, 0.065000
+#*#     0.085000, 0.045000, 0.020000, 0.005000, -0.005000, -0.040000, -0.025000
+#*#     0.040000, 0.005000, -0.010000, -0.015000, -0.025000, -0.060000, -0.060000
+#*#     0.025000, 0.000000, -0.005000, 0.000000, -0.005000, -0.040000, -0.035000
+#*#     0.015000, -0.005000, 0.000000, 0.005000, 0.020000, -0.005000, -0.010000
+#*# tension = 0.2
+#*# min_x = 20.0
+#*# algo = bicubic
+#*# y_count = 7
+#*# mesh_y_pps = 2
+#*# min_y = 30.0
+#*# x_count = 7
+#*# max_y = 259.98
+#*# mesh_x_pps = 2
+#*# max_x = 239.96
+#*#
+#*# [probe]
+#*# z_offset = 0.700
+#*#
+#*# [extruder]
+#*# control = pid
+#*# pid_kp = 47.970
+#*# pid_ki = 1.396
+#*# pid_kd = 412.126
+#*#
+#*# [heater_bed]
+#*# control = pid
+#*# pid_kp = 56.517
+#*# pid_ki = 1.826
+#*# pid_kd = 437.396

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2364,6 +2364,43 @@ sensor_type: temperature_host
 #   system file on a Raspberry Pi computer.
 ```
 
+### ADC Temp Sensor on i2c bus of MCU or Host
+
+All ADS1X1X i2c based sensors are supported and can be linked to extruders or heaters
+by inclusion of the following parameters wihtin [extruder] or [heater] config sections
+
+```
+sensor_type: ADS1X1X
+# This sensor type indicates that the i2c device driver is to be used
+probe_type: Generic 3950
+# The probe type indicates the calculation profile to use for the raw data from the
+# ADC device
+pullup_resistor: 4700
+# A setting that defines the physical wiring method of the sensor.  This is for a
+# single-ended wiring of a common PT100 thermistor
+i2c_mcu: mcu
+# Indicates whether to use mcu or host i2c bus
+i2c_bus: i2c1b
+# The name of the bus to use for the indicated mcu/host.  Example shown is an
+# RP2040 bus selection
+ads1x1_chip: 5
+# A number indicating which device is used.  Options are: ADS1013 - 3, ADS1014 - 4,
+# ADS1015 - 5, ADS1113 - 13, ADS1114 - 14, and ADS1115 - 15
+ads1x1_mux: 16384 # AIN0
+# A hex number in decimal form that indicates which device port you are using
+# There are four possible ports, depending upon device wiring and
+# two further options for single-ended or differential wireing.  See constant ADS1X1X_MUX in file klippy/extras/ads1x1x.py for more details.
+# Pullup voltage on thermistor
+adc_voltage: 3.265
+# The suppy voltage for the device.
+# Sensor is reading this amount different from external measuring device
+voltage_offset: -0.295
+# The differential voltage from the supplied voltage to the maximum pull-up voltage that the Device Unter Test (thermistor) sees.
+# ads1x1_addr: GND
+# Default value is GND.  There can be up to four addressed devices depending upon
+# wiring of the device.  Check the datasheet for details.
+```
+
 ### DS18B20 temperature sensor
 
 DS18B20 is a 1-wire (w1) digital temperature sensor. Note that this sensor is not intended for use with extruders and heater beds, but rather for monitoring ambient temperature (C). These sensors have range up to 125 C, so are usable for e.g. chamber temperature monitoring. They can also function as simple fan/heater controllers. DS18B20 sensors are only supported on the "host mcu", e.g. the Raspberry Pi. The w1-gpio Linux kernel module must be installed.

--- a/klippy/extras/ads1x1x.py
+++ b/klippy/extras/ads1x1x.py
@@ -1,0 +1,448 @@
+# Support for I2C based ADS1013, ADS1014, ADS1015, ADS1113
+#   , ADS1114, ADS1115 sensors
+#
+# Copyright (C) 2022  Kevin Peck <kevindpeck@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+from . import bus
+from . import adc_temperature
+
+# Supported chip types
+ADS1X1X_CHIP_TYPE = {
+    'ADS1013': 3,
+    'ADS1014': 4,
+    'ADS1015': 5,
+    'ADS1113': 13,
+    'ADS1114': 14,
+    'ADS1115': 15
+}
+# Address is defined by how the address pin is wired
+ADS1X1X_CHIP_ADDR = {
+    'GND': 0x48,
+    'VCC': 0x49,
+    'SDA': 0x4a,
+    'SCL': 0x4b
+}
+
+# Chip "pointer" registers
+ADS1X1X_REG_POINTER_MASK = 0x03
+ADS1X1X_REG_POINTER = {
+    'CONVERSION': 0x00,
+    'CONFIG': 0x01,
+    'LO_THRESH': 0x02,
+    'HI_THRESH': 0x03
+}
+
+# Config register masks
+ADS1X1X_REG_CONFIG = {
+    'OS_MASK': 0x8000,
+    'MULTIPLEXER_MASK': 0x7000,
+    'PGA_MASK': 0x0E00,
+    'MODE_MASK': 0x0100,
+    'DATA_RATE_MASK': 0x00E0,
+    'COMPARATOR_MODE_MASK': 0x0010,
+    'COMPARATOR_POLARITY_MASK': 0x0008,
+    # Determines if ALERT/RDY pin latches once asserted
+    'COMPARATOR_LATCHING_MASK': 0x0004,
+    'COMPARATOR_QUEUE_MASK': 0x0003
+}
+
+# Config register bits
+#   Read: bit = 1 when device is not performing a conversion
+ADS1X1X_REG_CONFIG_OS_IDLE=0x8000
+
+#
+# The following enums are to be used with the configuration functions.
+#
+ADS1X1X_OS = {
+    'OS_SINGLE': 0x8000 # Single-conversion
+}
+
+ADS1X1X_MUX = {
+    'MUX_DIFF_0_1': 0x0000,  # Differential P = AIN0, N = AIN1 0
+    'MUX_DIFF_0_3': 0x1000,  # Differential P = AIN0, N = AIN3 4096
+    'MUX_DIFF_1_3': 0x2000,  # Differential P = AIN1, N = AIN3 8192
+    'MUX_DIFF_2_3': 0x3000,  # Differential P = AIN2, N = AIN3 12288
+    'MUX_SINGLE_0': 0x4000,  # Single-ended (ADS1015: AIN0 16384)
+    'MUX_SINGLE_1': 0x5000,  # Single-ended (ADS1015: AIN1 20480)
+    'MUX_SINGLE_2': 0x6000,  # Single-ended (ADS1015: AIN2 24576)
+    'MUX_SINGLE_3': 0x7000   # Single-ended (ADS1015: AIN3 28672)
+}
+
+ADS1X1X_PGA = {
+    'PGA_6144': 0x0000,  # +/-6.144V range = Gain 2/3
+    'PGA_4096': 0x0200,  # +/-4.096V range = Gain 1
+    'PGA_2048': 0x0400,  # +/-2.048V range = Gain 2
+    'PGA_1024': 0x0600,  # +/-1.024V range = Gain 4
+    'PGA_512': 0x0800,  # +/-0.512V range = Gain 8
+    'PGA_256': 0x0A00  # +/-0.256V range = Gain 16
+}
+ADS1X1X_PGA_SCALAR16 = {
+    0x0000: 6.144 / 32767.0,  # +/-6.144V range = Gain 2/3
+    0x0200: 4.096 / 32767.0,  # +/-4.096V range = Gain 1
+    0x0400: 2.048 / 32767.0,  # +/-2.048V range = Gain 2
+    0x0600: 1.024 / 32767.0,  # +/-1.024V range = Gain 4
+    0x0800: 0.512 / 32767.0,  # +/-0.512V range = Gain 8
+    0x0A00: 0.256 / 32767.0  # +/-0.256V range = Gain 16
+}
+ADS1X1X_PGA_SCALAR12 = {
+    0x0000: 6.144 / 2047.0,  # +/-6.144V range = Gain 2/3
+    0x0200: 4.096 / 2047.0,  # +/-4.096V range = Gain 1
+    0x0400: 2.048 / 2047.0,  # +/-2.048V range = Gain 2
+    0x0600: 1.024 / 2047.0,  # +/-1.024V range = Gain 4
+    0x0800: 0.512 / 2047.0,  # +/-0.512V range = Gain 8
+    0x0A00: 0.256 / 2047.0  # +/-0.256V range = Gain 16
+}
+ADS1X1X_MODE = {
+    'MODE_CONTINUOUS': 0x0000,  # Continuous conversion mode
+    'MODE_SINGLE_SHOT': 0x0100  # Power-down single-shot mode
+}
+
+ADS1X1X_I2C_SPEED = {
+    # ADS101x
+    'ADS101x_128': 0x0000,  # 128 samples per second
+    'ADS101x_250': 0x0020,  # 250 samples per second
+    'ADS101x_490': 0x0040,  # 490 samples per second
+    'ADS101x_920': 0x0060,  # 920 samples per second
+    'ADS101x_1600': 0x0080,  # 1600 samples per second
+    'ADS101x_2400': 0x00a0,  # 2400 samples per second
+    'ADS101x_3300': 0x00c0,  # 3300 samples per second
+    # ADS111x
+    'ADS111x_8': 0x0000,  # 8 samples per second
+    'ADS111x_16': 0x0020,  # 16 samples per second
+    'ADS111x_32': 0x0040,  # 32 samples per second
+    'ADS111x_64': 0x0060,  # 64 samples per second
+    'ADS111x_128': 0x0080,  # 128 samples per second
+    'ADS111x_250': 0x00a0,  # 250 samples per second
+    'ADS111x_475': 0x00c0,  # 475 samples per second
+    'ADS111x_860': 0x00e0  # 860 samples per second
+}
+ADS1X1X_COMPARATOR_MODE = {
+    'TRADITIONAL': 0x0000,  # Traditional comparator with hysteresis
+    'WINDOW': 0x0010  # Window comparator
+}
+
+ADS1X1X_COMPARATOR_POLARITY = {
+    'ACTIVE_LO': 0x0000,  # ALERT/RDY pin is low when active
+    'ACTIVE_HI': 0x0008  # ALERT/RDY pin is high when active
+}
+
+ADS1X1X_COMPARATOR_LATCHING = {
+    'NON_LATCHING': 0x0000,  # Non-latching comparator
+    'LATCHING': 0x0004  # Latching comparator
+}
+
+ADS1X1X_COMPARATOR_QUEUE = {
+    'QUEUE_1': 0x0000,  # Assert ALERT/RDY after one conversions
+    'QUEUE_2': 0x0001,  # Assert ALERT/RDY after two conversions
+    'QUEUE_4': 0x0002,  # Assert ALERT/RDY after four conversions
+    'QUEUE_NONE': 0x0003  # Disable the comparator and put ALERT/RDY
+                        # in high state
+}
+
+ADS1X1_OPERATIONS = {
+    'SET_MUX': 0,
+    'READ_CONVERSION': 1
+}
+
+class Node:
+    def __init__(self,data):
+        self.data = data
+        self.next = None
+
+class CircularLinkedList:
+    def __init__(self):
+        self.last = None
+    def add(self,data):
+        newNode = Node(data)
+        if self.last == None:
+            # First item in new list
+            self.last = newNode
+            # create link to iteself
+            self.last.next = self.last
+            return self.last
+        else:
+            # store the address of the current first node in the newNode
+            newNode.next = self.last.next
+        # make newNode as last
+        self.last.next = newNode
+
+
+ADS1X1X_REPORT_TIME = 800E-3
+# Temperature can be sampled at any time. Conversion is
+# very fast but each port shares the same conversion
+# register.  Select port, call for conversion, get result.
+ADS1X1X_MIN_REPORT_TIME = 4E-3
+I2C_SPEED = 400E3
+class ADS1X1X:
+    # Class variables
+    reactor = None
+    i2c = {} # {self.chip_addr: bus.MCU_I2C_from_config(), ... up to 4 devices}
+    sensor_instances = CircularLinkedList()
+    sample_timer = None
+    report_time = None
+    current_sensor = None
+    current_operation = None
+
+    @classmethod
+    def _sample_ads1x1(cls, eventtime):
+        # Initialize
+        measured_time = None
+        if(cls.current_sensor is None):
+            cls.current_sensor = cls.sensor_instances.last
+        if(cls.current_operation is None):
+            cls.current_operation = ADS1X1_OPERATIONS['SET_MUX']
+        # If sensor is allocated
+        if(cls.current_sensor is not None):
+            # State machine
+            if(cls.current_operation == ADS1X1_OPERATIONS['SET_MUX']):
+                # Set channel on current sensor, initiate conversion
+                try:
+                    cls.write_register(cls.current_sensor.data.chip_addr\
+                        ,ADS1X1X_REG_POINTER['CONFIG']\
+                        ,cls.current_sensor.data.config)
+                except Exception:
+                    logging.exception("ads1x1x: Error triggering mux")
+                    cls.current_sensor.data.temp = 0.0
+                    return cls.reactor.NEVER
+                # Set next operation
+                cls.current_operation = ADS1X1_OPERATIONS['READ_CONVERSION']
+            else:
+                if(cls.current_operation == \
+                    ADS1X1_OPERATIONS['READ_CONVERSION']):
+                    # Read result
+                    try:
+                        sample = \
+                            cls.read_register( \
+                                cls.current_sensor.data.chip_addr \
+                                ,ADS1X1X_REG_POINTER['CONVERSION'], 2)
+                    except Exception:
+                        logging.exception("ads1x1x: Error reading data")
+                        cls.current_sensor.data.temp = 0.0
+                        return cls.reactor.NEVER
+                    # Calc temp
+                    cls.current_sensor.data.temp = \
+                        cls.current_sensor.data.degrees_from_sample(sample)
+                    # Publish result
+                    measured_time = cls.reactor.monotonic()
+                    cls.current_sensor.data._callback( \
+                        cls.current_sensor.data.mcu.estimated_print_time( \
+                            measured_time), \
+                            cls.current_sensor.data.temp)
+                    # Move to next sensor
+                    cls.current_sensor = cls.current_sensor.next
+                    # Set next operation
+                    cls.current_operation = ADS1X1_OPERATIONS['SET_MUX']
+
+        # Set next execution time
+        if(measured_time is None):
+            measured_time = cls.reactor.monotonic()
+        return measured_time + cls.report_time / len(ADS1X1_OPERATIONS)
+
+    @classmethod
+    def read_register(cls, chip_addr, reg, read_len):
+        # read a single register
+        params = ADS1X1X.i2c[chip_addr].i2c_read([reg], read_len)
+        buff = bytearray(params['response'])
+        return (buff[0]<<8 | buff[1])
+
+    @classmethod
+    def write_register(cls, chip_addr, reg, data):
+        data = [
+            (reg & 0xFF), # Control register
+            ((data>>8) & 0xFF), # High byte
+            (data & 0xFF), # Lo byte
+        ]
+        ADS1X1X.i2c[chip_addr].i2c_write(data)
+
+    def __init__(self, config):
+        self.i2c_broadcast = bus.MCU_I2C_from_config(config, 0x00, I2C_SPEED)
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.chip = config.getint('ads1x1_chip'
+            , minval=ADS1X1X_CHIP_TYPE['ADS1013']
+            , maxval=ADS1X1X_CHIP_TYPE['ADS1015'])
+        self.chip_addr = config.getint('ads1x1_addr'
+            , ADS1X1X_CHIP_ADDR['GND']
+            , minval=ADS1X1X_CHIP_ADDR['GND']
+            , maxval=ADS1X1X_CHIP_ADDR['SCL'])
+        self.speed = config.getint('ads1x1_i2c_speed'
+            , ADS1X1X_I2C_SPEED['ADS101x_1600']
+            , minval=ADS1X1X_I2C_SPEED['ADS101x_128']
+            , maxval=ADS1X1X_I2C_SPEED['ADS111x_860'])
+        self.mux = config.getint('ads1x1_mux'
+            , ADS1X1X_MUX['MUX_SINGLE_0']
+            , minval=ADS1X1X_MUX['MUX_DIFF_0_1']
+            , maxval=ADS1X1X_MUX['MUX_SINGLE_3'])
+        self.pga = config.getint('ads1x1_pga'
+            , ADS1X1X_PGA['PGA_4096']
+            , minval=ADS1X1X_PGA['PGA_6144']
+            , maxval=ADS1X1X_PGA['PGA_256'])
+        self.mode = config.getint('ads1x1_mode'
+            , ADS1X1X_MODE['MODE_SINGLE_SHOT']
+            , minval=ADS1X1X_MODE['MODE_CONTINUOUS']
+            , maxval=ADS1X1X_MODE['MODE_SINGLE_SHOT'])
+        self.comp_mode = config.getint('ads1x1_comp_mode'
+            , ADS1X1X_COMPARATOR_MODE['TRADITIONAL']
+            , minval=ADS1X1X_COMPARATOR_MODE['TRADITIONAL']
+            , maxval=ADS1X1X_COMPARATOR_MODE['WINDOW'])
+        self.comp_polarity = config.getint('ads1x1_comp_polarity'
+            , ADS1X1X_COMPARATOR_POLARITY['ACTIVE_LO']
+            , minval=ADS1X1X_COMPARATOR_POLARITY['ACTIVE_LO']
+            , maxval=ADS1X1X_COMPARATOR_POLARITY['ACTIVE_HI'])
+        self.comp_latching = config.getint('ads1x1_comp_latching'
+            , ADS1X1X_COMPARATOR_LATCHING['NON_LATCHING']
+            , minval=ADS1X1X_COMPARATOR_LATCHING['NON_LATCHING']
+            , maxval=ADS1X1X_COMPARATOR_LATCHING['LATCHING'])
+        self.comp_queue = config.getint('ads1x1_comp_queue'
+            , ADS1X1X_COMPARATOR_QUEUE['QUEUE_NONE']
+            , minval=ADS1X1X_COMPARATOR_QUEUE['QUEUE_1']
+            , maxval=ADS1X1X_COMPARATOR_QUEUE['QUEUE_NONE'])
+        if( self.chip_addr not in ADS1X1X.i2c):
+            ADS1X1X.i2c[self.chip_addr] = bus.MCU_I2C_from_config(config
+                , self.chip_addr, I2C_SPEED)
+        else:
+            # Dummy read of parameters to avoid config error
+            config.get('i2c_mcu', 'mcu')
+            config.getint('i2c_speed', 100000)
+            config.get('i2c_bus', None)
+            config.getint('i2c_address', 0)
+
+        # Configure probe on sensor to use
+        self.adc_voltage = config.getfloat('adc_voltage', 5., above=0.)
+        self.voltage_offset = config.getfloat('voltage_offset', 0.0)
+        self.pullup_resistor = config.getfloat('pullup_resistor', 4700.,
+            above=0.)
+        # Find probe for voltage to temp conversion function/table
+        for probe_type, params in adc_temperature.DefaultVoltageSensors:
+            if(probe_type == config.get('probe_type')):
+                self.converter = adc_temperature.ConvertADCtoTemperature( \
+                    adc_temperature.LinearVoltage(config, params))
+                break
+        # Find probe for resistance to temp conversion function/table
+        if(probe_type != config.get('probe_type')):
+            for probe_type, params in \
+                adc_temperature.DefaultResistanceSensors:
+                if(probe_type == config.get('probe_type')):
+                    self.converter = \
+                        adc_temperature.ConvertADCtoTemperature( \
+                        adc_temperature.LinearResistance(config, params))
+                    break
+        # Attempt to match against existing thermistors, generate conversion
+        # table
+        if(probe_type != config.get('probe_type')):
+            pheaters = config.get_printer().load_object(config, "heaters")
+            probe_config = \
+                pheaters.sensor_factories[config.get('probe_type')](config) \
+                    .adc_convert
+            all_temps = [float(i) for i in range(1, 351)]
+            adcs = [(t, probe_config.calc_adc(t)) for t in all_temps]
+            rs = [(t,self.pullup_resistor * adc / (1.0 - adc)) \
+                for t, adc in adcs]
+            if( probe_config is not None ):
+                self.converter = adc_temperature.ConvertADCtoTemperature( \
+                        adc_temperature.LinearResistance(config, rs))
+                probe_type = config.get('probe_type')
+
+        if(probe_type != config.get('probe_type')):
+            logging.error("Probe '%s' not found in adc_temperature for %s" \
+                % (config.get('probe_type'), self.name));
+        self.mcu = ADS1X1X.i2c[self.chip_addr].get_mcu()
+        # Initialize and keep the smallest time
+        if(ADS1X1X.report_time is None):
+            ADS1X1X.report_time = config.getfloat('ads1x1_report_time'
+                , ADS1X1X_REPORT_TIME
+                , minval=ADS1X1X_MIN_REPORT_TIME)
+        else:
+            report_time = config.getfloat('ads1x1_report_time'
+                , ADS1X1X_REPORT_TIME
+                , minval=ADS1X1X_MIN_REPORT_TIME)
+            ADS1X1X.report_time = min(ADS1X1X.report_time, report_time)
+
+        # Set up 2-byte configuration that will be used with each request
+        self.config = 0
+        self.config |= (ADS1X1X_OS['OS_SINGLE'] \
+            & ADS1X1X_REG_CONFIG['OS_MASK'])
+        self.config |= (self.mux & ADS1X1X_REG_CONFIG['MULTIPLEXER_MASK'])
+        self.config |= (self.pga & ADS1X1X_REG_CONFIG['PGA_MASK'])
+        self.config |= (self.mode & ADS1X1X_REG_CONFIG['MODE_MASK'])
+        self.config |= (self.speed & ADS1X1X_REG_CONFIG['DATA_RATE_MASK'])
+        self.config |= (self.comp_mode \
+            & ADS1X1X_REG_CONFIG['COMPARATOR_MODE_MASK'])
+        self.config |= (self.comp_polarity \
+            & ADS1X1X_REG_CONFIG['COMPARATOR_POLARITY_MASK'])
+        self.config |= (self.comp_latching \
+            & ADS1X1X_REG_CONFIG['COMPARATOR_LATCHING_MASK'])
+        self.config |= (self.comp_queue \
+            & ADS1X1X_REG_CONFIG['COMPARATOR_QUEUE_MASK'])
+        logging.info("ADS1x1: Chip Type %#x Chip Addr %#x Pin ID %#x for %s" \
+            % (self.chip, self.chip_addr, self.mux, self.name))
+
+        self.temp = self.min_temp = self.max_temp = 0.0
+
+        ADS1X1X.sensor_instances.add(self)
+        self.printer.add_object("ads1x1 " + self.name, self)
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+        self.printer.register_event_handler("klippy:shutdown",
+            self.reset_all_devices)
+
+    def handle_connect(self):
+        # Only once
+        if(ADS1X1X.sample_timer is None):
+            # Init all devices on bus for this kind of device
+            self.i2c_broadcast.i2c_write([0x06, 0x00, 0x00])
+            # Register timer
+            ADS1X1X.reactor = self.printer.get_reactor()
+            ADS1X1X.sample_timer = \
+                ADS1X1X.reactor.register_timer(ADS1X1X._sample_ads1x1)
+            ADS1X1X.reactor.update_timer(self.sample_timer, ADS1X1X.reactor.NOW)
+
+    def reset_all_devices(self, print_time=0.):
+        # Init all devices on bus for this kind of device
+        self.i2c_broadcast.i2c_write([0x06, 0x00, 0x00])
+
+    def setup_minmax(self, min_temp, max_temp):
+        self.min_temp = min_temp
+        self.max_temp = max_temp
+
+    def setup_callback(self, cb):
+        self._callback = cb
+
+    def get_report_time_delta(self):
+        return self.report_time
+
+    def degrees_from_sample(self, result):
+        # The sample is encoded in the top 12 or full 16 bits
+        # Value's meaning is defined by ADS1X1X_REG_CONFIG['PGA_MASK']
+        if self.chip == ADS1X1X_CHIP_TYPE['ADS1013'] \
+            or self.chip == ADS1X1X_CHIP_TYPE['ADS1014'] \
+            or self.chip == ADS1X1X_CHIP_TYPE['ADS1015'] :
+            result >>= 4
+            volts = result * ADS1X1X_PGA_SCALAR12[self.pga]
+        else:
+            volts = result * ADS1X1X_PGA_SCALAR16[self.pga]
+        temp = self.converter.calcTemp( (volts - self.voltage_offset) \
+            / self.adc_voltage )
+        # Debugging statement
+        #logging.info(\
+        #    "ADS1x1 (%02x,%02x): Read %#x Volts %.3f Scale %.4f Temp %.3f"
+        #    % (self.chip_addr, self.mux, result, volts - self.voltage_offset
+        #        , (volts - self.voltage_offset) / self.adc_voltage, temp) )
+        # Check if result is within limits
+        if temp < self.min_temp or temp > self.max_temp:
+            self.printer.invoke_shutdown(
+                "ADS1X1X temperature %0.1f outside range of %0.1f:%.01f"
+                % (temp, self.min_temp, self.max_temp))
+        return temp
+
+    def get_status(self, eventtime):
+        return {
+            'temperature': round(self.temp, 2),
+        }
+
+def load_config(config):
+    # Register sensor
+    pheaters = config.get_printer().load_object(config, "heaters")
+    pheaters.add_sensor_factory("ADS1X1X", ADS1X1X)

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -21,6 +21,9 @@
 # Load "LM75" sensor
 [lm75]
 
+# Load "ADS1X1X" sensor
+[ads1x1x]
+
 # Load "MAX6675", "MAX31855", "MAX31856", and "MAX31865" sensors
 [spi_temperature]
 

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -22,9 +22,11 @@ class PinResolver:
         self.aliases = {}
         self.active_pins = {}
     def reserve_pin(self, pin, reserve_name):
-        if pin in self.reserved and self.reserved[pin] != reserve_name:
-            raise error("Pin %s reserved for %s - can't reserve for %s" % (
-                pin, self.reserved[pin], reserve_name))
+# This constraint is too restrictive for multiple bus configuration options
+# ex: RP2040
+#        if pin in self.reserved and self.reserved[pin] != reserve_name:
+#            raise error("Pin %s reserved for %s - can't reserve for %s" % (
+#                pin, self.reserved[pin], reserve_name))
         self.reserved[pin] = reserve_name
     def alias_pin(self, alias, pin):
         if alias in self.aliases and self.aliases[alias] != pin:


### PR DESCRIPTION
ADC1X1X is a series of i2c bus chips with high sample rate and multiple channels.
Each channel can be mapped to a heater device and use the existing sensor math
and/or lookup tables.  Documentation is added.  A sample configuration is also
included (printer-picksix-v02.cfg).

Signed-off-by: Kevin Peck <kevindpeck@gmail.com>